### PR TITLE
code cleanup (macfuse->osxfuse)

### DIFF
--- a/MFCore/MFCore.h
+++ b/MFCore/MFCore.h
@@ -39,7 +39,7 @@ void mfcLaunchMenuling();
 void mfcKaboomMacfusion();
 
 // FUSE versioning
-NSString* mfcGetMacFuseVersion();
+NSString* mfcGetFuseVersion();
 
 // Trashing
 void mfcSetupTrashMonitoring();

--- a/MFCore/MFCore.m
+++ b/MFCore/MFCore.m
@@ -133,8 +133,8 @@ BOOL mfcSetStateForAgentLoginItem(BOOL state) {
 	return YES;
 }
 
-NSString *mfcGetMacFuseVersion() {
-	NSDictionary *fuseData = [NSDictionary dictionaryWithContentsOfFile:@"/Library/Filesystems/fusefs.fs/Contents/Info.plist"];
+NSString *mfcGetFuseVersion() {
+	NSDictionary *fuseData = [NSDictionary dictionaryWithContentsOfFile:@"/Library/Filesystems/osxfuse.fs/Contents/Info.plist"];
 	return [fuseData objectForKey: @"CFBundleVersion"];
 }
 

--- a/MFCore/MFPreferencesController.m
+++ b/MFCore/MFPreferencesController.m
@@ -40,8 +40,8 @@
 - (void)awakeFromNib {
 	[agentLoginItemButton setState:mfcGetStateForAgentLoginItem()];
 	[menuLoginItemButton setState:[_sharedPreferences getBoolForPreference: kMFPrefsAutoloadMenuling]];
-	NSString *macfuseVersion = mfcGetMacFuseVersion();
-	NSString *versionString = macfuseVersion ? [NSString stringWithFormat: @"MacFuse Version %@ Found", macfuseVersion] : @"MacFuse not Found!";
+	NSString *fuseVersion = mfcGetFuseVersion();
+	NSString *versionString = fuseVersion ? [NSString stringWithFormat: @"FUSE Version %@ Found", fuseVersion] : @"FUSE not Found!";
 	[fuseVersionTextField setStringValue: versionString];
 	NSToolbar *toolbar = [[NSToolbar alloc] initWithIdentifier: @"Preferences"];
 	[toolbar setDelegate:self];


### PR DESCRIPTION
This part of the code is currently not in use, but we can use it in the future to show the FUSE version being used in the preferences pane.

The change is to preparation for that.